### PR TITLE
FIX issue that output of NGSI to Worldmap node was 'no response object'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## node-red-contrib-letsfiware-NGSI v0.14.0-next
 
+-  FIX issue that output of NGSI to Worldmap node was 'no response object' (#139)
 -  ADD prettier command (#138)
 -  FIX forbidden option that had no effect (#137)
 -  ADD GitHub action to close inactive issues (#136)

--- a/src/nodes/NGSI/to-worldmap/to-worldmap.js
+++ b/src/nodes/NGSI/to-worldmap/to-worldmap.js
@@ -103,7 +103,8 @@ module.exports = function (RED) {
         }
         pois.push(poi);
       });
-      node.send({ payload: pois });
+      msg.payload = pois;
+      node.send(msg);
     });
   }
   RED.nodes.registerType('NGSI to worldmap', ngsi2worldmap);


### PR DESCRIPTION
## Proposed changes

This PR fixes issue that output of NGSI to Worldmap node was 'no response object'.

## Types of changes

What types of changes does your code introduce to the project: _Put an `x` in the boxes that apply_

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Update only documentation, not any source code.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

-   [X] I have read the [CONTRIBUTING](https://github.com/lets-fiware/node-red-contrib-letsfiware-NGSI/blob/main/CONTRIBUTING.md) doc
-   [ ] I have signed the [CLA](https://github.com/lets-fiware/node-red-contrib-letsfiware-NGSI/blob/main/node-red-contrib-letsfiware-NGSI-individual-cla.pdf)
-   [X] I have updated the change log (CHANGELOG.md)
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation (if appropriate)
-   [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A